### PR TITLE
Updated to run on PAM 7.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,25 +11,25 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-api</artifactId>
-      <version>7.7.0.Final-redhat-8</version>
+      <version>7.33.0.Final-redhat-00002</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-internal</artifactId>
-      <version>7.7.0.Final-redhat-8</version>
+      <version>7.33.0.Final-redhat-00002</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-core</artifactId>
-      <version>7.7.0.Final-redhat-8</version>
+      <version>7.33.0.Final-redhat-00002</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-persistence-jaxb</artifactId>
-      <version>7.7.0.Final-redhat-8</version>
+      <version>7.33.0.Final-redhat-00002</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -57,7 +57,7 @@
       <plugin>
         <groupId>org.kie</groupId>
         <artifactId>kie-maven-plugin</artifactId>
-        <version>7.7.0.Final-redhat-8</version>
+        <version>7.33.0.Final-redhat-00002</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>


### PR DESCRIPTION
This business process would not build on PAM 7.7 because certain maven artifacts couldn't be retrieved.